### PR TITLE
separate multiple plugins with quotes each

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -57,7 +57,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   : "${ROUNDCUBEMAIL_LOG_DIR:=/var/log/roundcubemail}"
 
   if [ ! -e config/config.inc.php ]; then
-    ROUNDCUBEMAIL_PLUGINS_PHP=`echo "${ROUNDCUBEMAIL_PLUGINS}" | sed -E "s/[, ]+/', '/"`
+    ROUNDCUBEMAIL_PLUGINS_PHP=`echo "${ROUNDCUBEMAIL_PLUGINS}" | sed -E "s/[, ]+/', '/g"`
     mkdir -p ${ROUNDCUBEMAIL_TEMP_DIR} && chown www-data ${ROUNDCUBEMAIL_TEMP_DIR}
     mkdir -p ${ROUNDCUBEMAIL_LOG_DIR} && chown www-data ${ROUNDCUBEMAIL_LOG_DIR}
     touch config/config.inc.php


### PR DESCRIPTION
envvar: `ROUNDCUBEMAIL_PLUGINS=archive,enigma,jqueryui,managesieve,identity_smtp`

resulting config.inc.php included
`$config['plugins'] = ['archive', 'enigma,jqueryui,managesieve,identity_smtp'];`

now it includes 
`$config['plugins'] = ['archive', 'enigma', 'jqueryui', 'managesieve', 'identity_smtp'];`